### PR TITLE
Fix episode count on completed anime

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,7 +183,7 @@ def EXPORT_TO_MAL(API_KEY, ID, watchlist_zoro):
             payload = {"status": convert[i]}
 
             if i == 'Completed':
-                payload["num_watched_episodes"] = -1
+                payload["num_watched_episodes"] = 99999
 
             response = requests.put(url,
                                     headers=headers,


### PR DESCRIPTION
Set number of watched episodes as value '99999', so that MAL automatically sets the max possible watched episode count, which is the total number of available episodes for completed animes.